### PR TITLE
access class directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "git://github.com/tommyh/jasmine-react.git"
   },
   "devDependencies": {
-    "semver": "^4.3.4",
     "browserify": "^4.2.3",
     "grunt": "^0.4.5",
     "grunt-karma": "^0.8.3",
@@ -22,5 +21,8 @@
     "karma-react-jsx-preprocessor": "^0.1.1",
     "react": "^0.12.1",
     "react-tools": "^0.12.1"
+  },
+  "dependencies": {
+    "semver": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/tommyh/jasmine-react.git"
   },
   "devDependencies": {
+    "semver": "^4.3.4",
     "browserify": "^4.2.3",
     "grunt": "^0.4.5",
     "grunt-karma": "^0.8.3",

--- a/src/jasmine-react.js
+++ b/src/jasmine-react.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var semver = require('semver');
 
 var spies = [],
   componentStubs = [],
@@ -44,6 +45,9 @@ var jasmineReact = {
   },
 
   classComponentConstructor: function(klass){
+    if(semver.gt(React.version, "0.13.0")) { // React 0.13.0
+      return klass;
+    }
     return klass.type ||                // React 0.11.1
            klass.componentConstructor;  // React 0.8.0
   },


### PR DESCRIPTION
When you call `classComponentConstructor`, React warn the below message.
So I fixed it to access class directly.
Please check my commits.

```
WARN LOG: 'Warning: exports.type is deprecated. Use exports directly to access the class.'
```
