### PR TITLE
Add valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "git://github.com/tommyh/jasmine-react.git"
   },
+  "license": "MIT",
   "devDependencies": {
     "browserify": "^4.2.3",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Adds the "MIT" license identifier from https://spdx.org/licenses/. 

See [here](https://github.com/npm/npm/issues/8918) for some interesting background minutes. This should help users which use tools to whitelist packages based on the license identifier in `package.json`, where `jasmine-react` is currently being treated as proprietary software since the license cannot be automatically determined.
